### PR TITLE
SYS-1081: Allow deletion without receipt of CDL MARC records

### DIFF
--- a/scripts/bin/process_etds
+++ b/scripts/bin/process_etds
@@ -406,8 +406,7 @@ _delete_old_etds() {
   find ${FILES_ARCHIVE} -type f -name "etdadmin*.zip" -mtime +${DAYS_TO_KEEP} | while read ETD; do
     _get_proquest_id ${ETD}
     _DEBUG "Deleting old files for ${PROQUEST_ID}..."
-    if _has_status ${PROQUEST_ID} ${STATUS_TO_CDL} &&
-       _has_status ${PROQUEST_ID} ${STATUS_CDL_MARC}
+    if _has_status ${PROQUEST_ID} ${STATUS_TO_CDL}
     then
       # Delete the zip archive file
       _DEBUG "  Deleting ${ETD}"


### PR DESCRIPTION
Implements [SYS-1081](https://jira.library.ucla.edu/browse/SYS-1081).

Deletion of old ETDs used to depend on receiving MARC records from CDL, for load into Voyager.  We no longer do this with Alma, so allow deletion of old files 31 days after sending the ETD to CDL.
